### PR TITLE
Server launch/Reload replacing mobs with custom mobs

### DIFF
--- a/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
@@ -1,5 +1,6 @@
 package nl.pjiwm.kaizominecraft;
 
+import nl.pjiwm.kaizominecraft.managers.CustomMobWorldSpawner;
 import nl.pjiwm.kaizominecraft.managers.EventRegisterer;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -11,6 +12,13 @@ public final class Kaizo extends JavaPlugin {
         // Plugin startup logic
         PluginManager pm = getServer().getPluginManager();
         EventRegisterer.registerEvents(pm, this);
+//        temporary because if the server does not have a world named world it will cause problems!
+        try {
+            CustomMobWorldSpawner.replaceMobs(getServer().getWorld("world"));
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+            CustomMobWorldSpawner.replaceAllWorlds(this);
+        }
     }
 
     @Override

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnBuffedMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnBuffedMob.java
@@ -24,7 +24,6 @@ public class SpawnBuffedMob implements Listener {
         if (entity instanceof Monster) {
             buffMonster(entity);
         }
-
         switch (entity.getType()) {
             case CREEPER:
                 buffCreeper((Creeper) entity);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -26,10 +26,10 @@ public class SpawnCustomMob implements Listener {
     }
 
 
-
     /**
-     * removes any non custom mob if there's a custom mob variant
-     * and checks with which custom mob to replace with.
+     * Every entity that's being spawned gets passed down to the mob manager.
+     * This way it can be checked if it can be replaced with a custom mob.
+     * @param e - the event upon a new entity/mob spawns in the world.
      */
     @EventHandler
     public void spawnEntity(EntitySpawnEvent e) {

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -2,6 +2,7 @@ package nl.pjiwm.kaizominecraft.listeners;
 
 import net.minecraft.server.v1_16_R3.Entity;
 import net.minecraft.server.v1_16_R3.WorldServer;
+import nl.pjiwm.kaizominecraft.managers.CustomMobManager;
 import nl.pjiwm.kaizominecraft.mobs.*;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -24,18 +25,7 @@ public class SpawnCustomMob implements Listener {
         entityKey = new NamespacedKey(plugin, "custom");
     }
 
-    /**
-     * Spawns a custom NMS mob into a minecraft world
-     * @param entity the custom mob that will be spawned and replace the original mob
-     */
-    private void spawnMob(Entity entity) {
-        Location location = entity.getBukkitEntity().getLocation();
-        CraftLivingEntity newEntity = (CraftLivingEntity) entity.getBukkitEntity();
-        PersistentDataContainer dataContainer =  newEntity.getPersistentDataContainer();
-        dataContainer.set(entityKey, PersistentDataType.STRING, "custom");
-        WorldServer world = ((CraftWorld) Objects.requireNonNull(location.getWorld())).getHandle();
-        world.addEntity(entity, CreatureSpawnEvent.SpawnReason.NATURAL);
-    }
+
 
     /**
      * removes any non custom mob if there's a custom mob variant
@@ -43,47 +33,7 @@ public class SpawnCustomMob implements Listener {
      */
     @EventHandler
     public void spawnEntity(EntitySpawnEvent e) {
-        PersistentDataContainer entityContainer = e.getEntity().getPersistentDataContainer();
-        Location spawnLocation = e.getEntity().getLocation();
-//        this prevents entity from infinitely being replaced
-        if(entityContainer.has(entityKey, PersistentDataType.STRING)) {
-            return;
-        }
-        switch(e.getEntity().getType()) {
-            case CHICKEN:
-                e.getEntity().remove();
-                spawnMob(new CustomChicken(spawnLocation));
-                System.out.println("kip");
-                break;
-            case SHEEP:
-                e.getEntity().remove();
-                spawnMob(new CustomSheep(spawnLocation));
-                System.out.println("schaap");
-                break;
-            case PIG:
-                e.getEntity().remove();
-                spawnMob(new CustomPig(spawnLocation));
-                break;
-            case COW:
-                e.getEntity().remove();
-                spawnMob(new CustomCow(spawnLocation));
-                break;
-            case IRON_GOLEM:
-                e.getEntity().remove();
-                spawnMob(new CustomIronGolem(spawnLocation));
-                break;
-            case WOLF:
-                e.getEntity().remove();
-                spawnMob(new CustomWolf(spawnLocation));
-                break;
-            case ZOMBIFIED_PIGLIN:
-                e.getEntity().remove();
-                spawnMob(new CustomPigZombie(spawnLocation));
-                break;
-        }
-
-
-
+        CustomMobManager.replaceMob(e.getEntity());
     }
 
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -1,11 +1,9 @@
 package nl.pjiwm.kaizominecraft.listeners;
 
 import nl.pjiwm.kaizominecraft.managers.CustomMobManager;
-import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntitySpawnEvent;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public class SpawnCustomMob implements Listener {
 

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -8,12 +8,6 @@ import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class SpawnCustomMob implements Listener {
-    private NamespacedKey entityKey;
-
-    public SpawnCustomMob(JavaPlugin plugin) {
-        entityKey = new NamespacedKey(plugin, "custom");
-    }
-
 
     /**
      * Every entity that's being spawned gets passed down to the mob manager.

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -1,22 +1,11 @@
 package nl.pjiwm.kaizominecraft.listeners;
 
-import net.minecraft.server.v1_16_R3.Entity;
-import net.minecraft.server.v1_16_R3.WorldServer;
 import nl.pjiwm.kaizominecraft.managers.CustomMobManager;
-import nl.pjiwm.kaizominecraft.mobs.*;
-import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_16_R3.entity.CraftLivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
-
-import java.util.Objects;
 
 public class SpawnCustomMob implements Listener {
     private NamespacedKey entityKey;

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 public class CustomMobManager {
     public static NamespacedKey entityKey = new NamespacedKey(Kaizo.getPlugin(Kaizo.class), "custom");
-    
+
     /**
      * removes any non custom mob if there's a custom mob variant
      * and checks with which custom mob to replace with.

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
@@ -1,0 +1,68 @@
+package nl.pjiwm.kaizominecraft.managers;
+
+import net.minecraft.server.v1_16_R3.WorldServer;
+import nl.pjiwm.kaizominecraft.Kaizo;
+import nl.pjiwm.kaizominecraft.mobs.*;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_16_R3.entity.CraftLivingEntity;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Objects;
+
+public class CustomMobManager {
+    public static NamespacedKey entityKey = new NamespacedKey(Kaizo.getPlugin(Kaizo.class), "custom");
+
+    public static void replaceMob(Entity entity) {
+        Location spawnLocation = entity.getLocation();
+        PersistentDataContainer entityContainer = entity.getPersistentDataContainer();
+        if(entityContainer.has(entityKey, PersistentDataType.STRING)) {
+            return;
+        }
+        switch(entity.getType()) {
+            case CHICKEN:
+                entity.remove();
+                spawnMob(new CustomChicken(spawnLocation));
+                System.out.println("kip");
+                break;
+            case SHEEP:
+                entity.remove();
+                spawnMob(new CustomSheep(spawnLocation));
+                System.out.println("schaap");
+                break;
+            case PIG:
+                entity.remove();
+                spawnMob(new CustomPig(spawnLocation));
+                break;
+            case COW:
+                entity.remove();
+                spawnMob(new CustomCow(spawnLocation));
+                break;
+            case IRON_GOLEM:
+                entity.remove();
+                spawnMob(new CustomIronGolem(spawnLocation));
+                break;
+            case WOLF:
+                entity.remove();
+                spawnMob(new CustomWolf(spawnLocation));
+                break;
+            case ZOMBIFIED_PIGLIN:
+                entity.remove();
+                spawnMob(new CustomPigZombie(spawnLocation));
+                break;
+        }
+    }
+
+    private static void spawnMob(net.minecraft.server.v1_16_R3.Entity entity) {
+        Location location = entity.getBukkitEntity().getLocation();
+        CraftLivingEntity newEntity = (CraftLivingEntity) entity.getBukkitEntity();
+        PersistentDataContainer dataContainer =  newEntity.getPersistentDataContainer();
+        dataContainer.set(entityKey, PersistentDataType.STRING, "custom");
+        WorldServer world = ((CraftWorld) Objects.requireNonNull(location.getWorld())).getHandle();
+        world.addEntity(entity, CreatureSpawnEvent.SpawnReason.NATURAL);
+    }
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
@@ -31,12 +31,10 @@ public class CustomMobManager {
             case CHICKEN:
                 entity.remove();
                 spawnMob(new CustomChicken(spawnLocation));
-                System.out.println("kip");
                 break;
             case SHEEP:
                 entity.remove();
                 spawnMob(new CustomSheep(spawnLocation));
-                System.out.println("schaap");
                 break;
             case PIG:
                 entity.remove();

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobManager.java
@@ -16,14 +16,18 @@ import java.util.Objects;
 
 public class CustomMobManager {
     public static NamespacedKey entityKey = new NamespacedKey(Kaizo.getPlugin(Kaizo.class), "custom");
-
+    
+    /**
+     * removes any non custom mob if there's a custom mob variant
+     * and checks with which custom mob to replace with.
+     */
     public static void replaceMob(Entity entity) {
         Location spawnLocation = entity.getLocation();
         PersistentDataContainer entityContainer = entity.getPersistentDataContainer();
-        if(entityContainer.has(entityKey, PersistentDataType.STRING)) {
+        if (entityContainer.has(entityKey, PersistentDataType.STRING)) {
             return;
         }
-        switch(entity.getType()) {
+        switch (entity.getType()) {
             case CHICKEN:
                 entity.remove();
                 spawnMob(new CustomChicken(spawnLocation));
@@ -56,11 +60,14 @@ public class CustomMobManager {
                 break;
         }
     }
-
+    /**
+     * Spawns a custom NMS mob into a minecraft world
+     * @param entity the custom mob that will be spawned and replace the original mob
+     */
     private static void spawnMob(net.minecraft.server.v1_16_R3.Entity entity) {
         Location location = entity.getBukkitEntity().getLocation();
         CraftLivingEntity newEntity = (CraftLivingEntity) entity.getBukkitEntity();
-        PersistentDataContainer dataContainer =  newEntity.getPersistentDataContainer();
+        PersistentDataContainer dataContainer = newEntity.getPersistentDataContainer();
         dataContainer.set(entityKey, PersistentDataType.STRING, "custom");
         WorldServer world = ((CraftWorld) Objects.requireNonNull(location.getWorld())).getHandle();
         world.addEntity(entity, CreatureSpawnEvent.SpawnReason.NATURAL);

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
@@ -8,6 +8,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.List;
 
 public class CustomMobWorldSpawner {
+    /**
+     * Goes through all existing entities in a world and replaces them.
+     * If the mob does not have the namedSpaceKey "custom" of the type String
+     * and has a custom mob variant it will be removed and a new custom mob will be spawned instead.
+     * @param world - the world in which all mobs will be scanned.
+     */
     public static void replaceMobs(World world) {
         List<Entity> allEntities = world.getEntities();
         for(Entity entity : allEntities) {
@@ -18,6 +24,12 @@ public class CustomMobWorldSpawner {
         }
     }
 
+    /**
+     * gets all worlds from a server and does a scan on all entities on all worlds.
+     * On every world the replaceMobs method will be executed which replaces the mob with
+     * a custom mob if necessary.
+     * @param plugin - the main class/server plugin required to get all the servers worlds.
+     */
     public static void replaceAllWorlds(JavaPlugin plugin) {
         List<World> allWorlds = plugin.getServer().getWorlds();
         for(World world : allWorlds) {

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
@@ -1,0 +1,20 @@
+package nl.pjiwm.kaizominecraft.managers;
+
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.List;
+
+public class CustomMobWorldSpawner {
+    public static void replaceMobs(World world) {
+        List<Entity> allEntities = world.getEntities();
+        for(Entity entity : allEntities) {
+            if(!entity.getPersistentDataContainer().has(CustomMobManager.entityKey, PersistentDataType.STRING)) {
+                CustomMobManager.replaceMob(entity);
+            }
+
+        }
+    }
+
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
@@ -1,6 +1,7 @@
 package nl.pjiwm.kaizominecraft.managers;
 
 import org.bukkit.World;
+import org.bukkit.WorldType;
 import org.bukkit.entity.Entity;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -23,7 +24,6 @@ public class CustomMobWorldSpawner {
 
         }
     }
-
     /**
      * gets all worlds from a server and does a scan on all entities on all worlds.
      * On every world the replaceMobs method will be executed which replaces the mob with
@@ -33,6 +33,22 @@ public class CustomMobWorldSpawner {
     public static void replaceAllWorlds(JavaPlugin plugin) {
         List<World> allWorlds = plugin.getServer().getWorlds();
         for(World world : allWorlds) {
+            replaceMobs(world);
+        }
+    }
+    /**
+     * gets all worlds from a server and filters them on the world type.
+     * it does a scan on all entities on all worlds.
+     * On every world the replaceMobs method will be executed which replaces the mob with
+     * a custom mob if necessary.
+     * @param plugin - the main class/server plugin required to get all the servers worlds.
+     * @param environment - the type of world it should perform actions on.
+     * options: NORMAL/NETHER/THE_END/CUSTOM
+     */
+    public static void replaceAllWorlds(JavaPlugin plugin, World.Environment environment) {
+        List<World> allWorlds = plugin.getServer().getWorlds();
+        for(World world : allWorlds) {
+            if(world.getEnvironment().equals(environment))
             replaceMobs(world);
         }
     }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
@@ -3,6 +3,7 @@ package nl.pjiwm.kaizominecraft.managers;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.List;
 
@@ -17,4 +18,10 @@ public class CustomMobWorldSpawner {
         }
     }
 
+    public static void replaceAllWorlds(JavaPlugin plugin) {
+        List<World> allWorlds = plugin.getServer().getWorlds();
+        for(World world : allWorlds) {
+            replaceMobs(world);
+        }
+    }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
@@ -13,7 +13,7 @@ public class EventRegisterer {
 
 
     public static void registerEvents(PluginManager pm, JavaPlugin plugin) {
-        pm.registerEvents(new SpawnCustomMob(plugin), plugin);
+        pm.registerEvents(new SpawnCustomMob(), plugin);
         pm.registerEvents(new SpawnBuffedMob(), plugin);
         pm.registerEvents(new ProjectileBuff(), plugin);
         pm.registerEvents(new ArrowBuff(), plugin);


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

**Please provide enough information so that others can review your pull request:**
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
The switch case of mobs from the custom mob listener needs to be in its own class so it can be reused.
There needs to be a new class which runs on the startup and reload of the server.
This new class should check through a list of accessible worlds and get the entities in them.
For every entity that is not a custom mob, but does have a custom variant, it should be replaced.

**Explain the **details** for making this change. What existing problem does the pull request solve?**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
By adding this feature we solve the problem of already spawned in non-custom mobs being able to be replaced with custom ones.
As of now there is no way of replacing already spawned in mobs with custom mobs, only newly spawned mobs will immediately be replaced.

- [x] Separate switch case from custom mob listener in its own class
- [x] Create a new class that replaced already spawned in mobs
- [x] add the code to the startup script in the plugin
- [x] test if code works
- [x] decide on which functionality to use in terms of world options

**Test plan (required):**
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request has visual changes.

1. Wiping the world folder before launching the server with the updated plugin.
2. Console logging every entity that's being replaced
3. Joining the server
4. fly around and see if non-hostile mobs like pig, cows, sheep and chickens run away from the player immediately.

**Closing issues**
closes #9 

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
