### PR TITLE
Generating custom worlds for kaizo

### DIFF
--- a/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
@@ -11,9 +11,9 @@ public final class Kaizo extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
+        CustomWorldManager.geneRateWorlds();
         PluginManager pm = getServer().getPluginManager();
         EventRegisterer.registerEvents(pm, this);
-            CustomWorldManager.geneRateWorlds();
             CustomMobWorldSpawner.replaceMobs(getServer().getWorld(CustomWorldManager.OVERWORLD_NAME));
     }
 

--- a/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
@@ -1,6 +1,7 @@
 package nl.pjiwm.kaizominecraft;
 
 import nl.pjiwm.kaizominecraft.managers.CustomMobWorldSpawner;
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
 import nl.pjiwm.kaizominecraft.managers.EventRegisterer;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -12,13 +13,9 @@ public final class Kaizo extends JavaPlugin {
         // Plugin startup logic
         PluginManager pm = getServer().getPluginManager();
         EventRegisterer.registerEvents(pm, this);
-//        temporary because if the server does not have a world named world it will cause problems!
-        try {
-            CustomMobWorldSpawner.replaceMobs(getServer().getWorld("world"));
-        } catch (NullPointerException e) {
-            e.printStackTrace();
-            CustomMobWorldSpawner.replaceAllWorlds(this);
-        }
+            CustomWorldManager.geneRateWorlds();
+            CustomMobWorldSpawner.replaceMobs(getServer().getWorld(CustomWorldManager.OVERWORLD_NAME));
+
     }
 
     @Override

--- a/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/Kaizo.java
@@ -15,7 +15,6 @@ public final class Kaizo extends JavaPlugin {
         EventRegisterer.registerEvents(pm, this);
             CustomWorldManager.geneRateWorlds();
             CustomMobWorldSpawner.replaceMobs(getServer().getWorld(CustomWorldManager.OVERWORLD_NAME));
-
     }
 
     @Override

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/ArrowBuff.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/ArrowBuff.java
@@ -1,5 +1,6 @@
 package nl.pjiwm.kaizominecraft.listeners;
 
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Monster;
 import org.bukkit.event.EventHandler;
@@ -9,8 +10,16 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ArrowBuff implements Listener {
+    /**
+     * Replaces the arrows that have been shot by a bow.
+     * The arrows will be given poison and nausea effects.
+     */
     @EventHandler
     public void onShootBow(EntityShootBowEvent e) {
+        if(!CustomWorldManager.isCustomWorld(e.getEntity().getLocation().getWorld().getName())) {
+            return;
+        }
+
         if (e.getEntity() instanceof Monster) {
             Arrow arrow = (Arrow) e.getProjectile();
             PotionEffect poison = new PotionEffect(PotionEffectType.POISON, 40, 0, true, true,true);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -10,6 +10,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -23,38 +24,43 @@ public class CustomPortalListener implements Listener {
      * checks if the player is changing dimensions.
      * it will check if it's a custom world and link the portal to the other dimension which is also custom.
      * this way we can prevent players from entering portals in custom worlds and ending up in normal worlds.
-     * @param event - the event of a player entering a portal
+     * @param e - the event of a player entering a portal
      */
     @EventHandler
-    public void onPortal(PlayerPortalEvent event) {
-        System.out.println("debug - event called");
-        Player player = event.getPlayer();
+    public void onPortal(PlayerPortalEvent e) {
+        Player p = e.getPlayer();
 //      if it's not a custom world nothing special should be done.
-        if(!CustomWorldManager.isCustomWorld(event.getPlayer().getWorld().getName())) {
+        if(!CustomWorldManager.isCustomWorld(e.getPlayer().getWorld().getName())) {
             return;
         }
 
-        if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
-            event.setCanCreatePortal(true);
+        if (e.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
+            e.setCanCreatePortal(true);
             Location location;
-            if (player.getWorld() == getWorld()) {
-                location = new Location(getNether(), event.getFrom().getBlockX() / 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() / 8);
+            if (p.getWorld() == getWorld()) {
+                location = new Location(getNether(), e.getFrom().getBlockX() / 8, e.getFrom().getBlockY(), e.getFrom().getBlockZ() / 8);
             } else {
-                location = new Location(getWorld(), event.getFrom().getBlockX() * 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() * 8);
+                location = new Location(getWorld(), e.getFrom().getBlockX() * 8, e.getFrom().getBlockY(), e.getFrom().getBlockZ() * 8);
             }
 
-            event.setTo(location);
+            e.setTo(location);
         }
 //      unlike nether portals when a player goes from the end back to the overworld this event is not called for
-        if (event.getCause() == PlayerTeleportEvent.TeleportCause.END_PORTAL) {
-            if (player.getWorld() == getWorld()) {
+        if (e.getCause() == PlayerTeleportEvent.TeleportCause.END_PORTAL) {
+            if (p.getWorld() == getWorld()) {
                 // This is the vanilla location for obsidian platform.
-                Location loc = new Location(getEnd(), 100, 50, 0);
-                event.setTo(loc);
-                setObsidianPlatform(loc);
+                Location location = new Location(getEnd(), 100, 50, 0);
+                e.setTo(location);
+                setObsidianPlatform(location);
             }
         }
     }
+
+    @EventHandler
+    public void onEndLeave(PlayerChangedWorldEvent event) {
+        
+    }
+
     /**
      * grabs the custom end dimension and checks if it exists.
      * @return the custom over world dimension or if its not found the default over world.
@@ -102,13 +108,13 @@ public class CustomPortalListener implements Listener {
     /**
      * builds an obsidian platform the same way it does when a player enters the end in vanilla minecraft.
      * this mimicked behavior can be used to create obsidian platforms in other dimensions.
-     * @param loc - the starting location in which the platform should be build on.
+     * @param location - the starting location in which the platform should be build on.
      */
-    private void setObsidianPlatform(Location loc) {
-        Block block = loc.getBlock();
+    private void setObsidianPlatform(Location location) {
+        Block block = location.getBlock();
         for (int x = block.getX() - 2; x <= block.getX() + 2; x++) {
             for (int z = block.getZ() - 2; z <= block.getZ() + 2; z++) {
-                Block platformBlock = loc.getWorld().getBlockAt(x, block.getY() - 1, z);
+                Block platformBlock = location.getWorld().getBlockAt(x, block.getY() - 1, z);
                 if (platformBlock.getType() != Material.OBSIDIAN) {
                     platformBlock.setType(Material.OBSIDIAN);
                 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -64,7 +64,8 @@ public class CustomPortalListener implements Listener {
     @EventHandler
     public void onEndLeave(PlayerChangedWorldEvent e) {
         if(e.getFrom() == getEnd()) {
-            if(e.getPlayer().getBedSpawnLocation().getWorld() == getWorld()) {
+            World world = e.getPlayer().getBedSpawnLocation().getWorld();
+            if( world == getWorld() || world == getNether()) {
                 return;
             }
             e.getPlayer().teleport(getWorld().getSpawnLocation());

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -2,8 +2,11 @@ package nl.pjiwm.kaizominecraft.listeners;
 
 import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -16,47 +19,57 @@ public class CustomPortalListener implements Listener {
     public CustomPortalListener(JavaPlugin plugin) {
         this.server = plugin.getServer();
     }
+//  TODO check what works on this function
 
-//    @EventHandler
-//    public void onPortal(PlayerPortalEvent event) {
-//        Player player = event.getPlayer();
-//
-//        if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
+// seems like travelAgents is deprecated and the whole agent part isn't necessary anymore
+// code is from spigot forum: https://www.spigotmc.org/threads/create-world-with-nether-and-end.399952/
+// originally from Multiverse might be able to find their current mehod for this event if it doesn't work.
+    /**
+     *
+     * @param event - the event of a player entering a portal
+     */
+    @EventHandler
+    public void onPortal(PlayerPortalEvent event) {
+        Player player = event.getPlayer();
+
+        if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
 //            event.useTravelAgent(true);
 //            event.getPortalTravelAgent().setCanCreatePortal(true);
-//            Location location;
-//            if (player.getWorld() == getWorld()) {
-//                location = new Location(getNether(), event.getFrom().getBlockX() / 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() / 8);
-//            } else {
-//                location = new Location(getWorld(), event.getFrom().getBlockX() * 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() * 8);
-//            }
+            event.setCanCreatePortal(true);
+            Location location;
+            if (player.getWorld() == getWorld()) {
+                location = new Location(getNether(), event.getFrom().getBlockX() / 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() / 8);
+            } else {
+                location = new Location(getWorld(), event.getFrom().getBlockX() * 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() * 8);
+            }
 //            event.setTo(event.getPortalTravelAgent().findOrCreate(location));
-//        }
-//
-//        if (event.getCause() == PlayerTeleportEvent.TeleportCause.END_PORTAL) {
-//            if (player.getWorld() == getWorld()) {
-//                Location loc = new Location(getEnd(), 100, 50, 0); // This is the vanilla location for obsidian platform.
-//                event.setTo(loc);
-//                Block block = loc.getBlock();
-//                for (int x = block.getX() - 2; x <= block.getX() + 2; x++) {
-//                    for (int z = block.getZ() - 2; z <= block.getZ() + 2; z++) {
-//                        Block platformBlock = loc.getWorld().getBlockAt(x, block.getY() - 1, z);
-//                        if (platformBlock.getType() != Material.OBSIDIAN) {
-//                            platformBlock.setType(Material.OBSIDIAN);
-//                        }
-//                        for (int yMod = 1; yMod <= 3; yMod++) {
-//                            Block b = platformBlock.getRelative(BlockFace.UP, yMod);
-//                            if (b.getType() != Material.AIR) {
-//                                b.setType(Material.AIR);
-//                            }
-//                        }
-//                    }
-//                }
-//            } else if (player.getWorld() == getEnd()) {
-//                event.setTo(getWorld().getSpawnLocation());
-//            }
-//        }
-//    }
+            event.setTo(location);
+        }
+
+        if (event.getCause() == PlayerTeleportEvent.TeleportCause.END_PORTAL) {
+            if (player.getWorld() == getWorld()) {
+                Location loc = new Location(getEnd(), 100, 50, 0); // This is the vanilla location for obsidian platform.
+                event.setTo(loc);
+                Block block = loc.getBlock();
+                for (int x = block.getX() - 2; x <= block.getX() + 2; x++) {
+                    for (int z = block.getZ() - 2; z <= block.getZ() + 2; z++) {
+                        Block platformBlock = loc.getWorld().getBlockAt(x, block.getY() - 1, z);
+                        if (platformBlock.getType() != Material.OBSIDIAN) {
+                            platformBlock.setType(Material.OBSIDIAN);
+                        }
+                        for (int yMod = 1; yMod <= 3; yMod++) {
+                            Block b = platformBlock.getRelative(BlockFace.UP, yMod);
+                            if (b.getType() != Material.AIR) {
+                                b.setType(Material.AIR);
+                            }
+                        }
+                    }
+                }
+            } else if (player.getWorld() == getEnd()) {
+                event.setTo(getWorld().getSpawnLocation());
+            }
+        }
+    }
 
     private World getWorld() {
         World world;

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -1,0 +1,2 @@
+package nl.pjiwm.kaizominecraft.listeners;public class CustomPortalListener {
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -31,6 +31,10 @@ public class CustomPortalListener implements Listener {
     @EventHandler
     public void onPortal(PlayerPortalEvent event) {
         Player player = event.getPlayer();
+//        if it's not a custom world nothing special should be done.
+        if(!CustomWorldManager.isCustomWorld(event.getPlayer().getWorld().getName())) {
+            return;
+        }
 
         if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
 //            event.useTravelAgent(true);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -1,2 +1,71 @@
-package nl.pjiwm.kaizominecraft.listeners;public class CustomPortalListener {
+package nl.pjiwm.kaizominecraft.listeners;
+
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerPortalEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class CustomPortalListener implements Listener {
+    Server server;
+    public CustomPortalListener(JavaPlugin plugin) {
+        this.server = plugin.getServer();
+    }
+
+//    @EventHandler
+//    public void onPortal(PlayerPortalEvent event) {
+//        Player player = event.getPlayer();
+//
+//        if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
+//            event.useTravelAgent(true);
+//            event.getPortalTravelAgent().setCanCreatePortal(true);
+//            Location location;
+//            if (player.getWorld() == getWorld()) {
+//                location = new Location(getNether(), event.getFrom().getBlockX() / 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() / 8);
+//            } else {
+//                location = new Location(getWorld(), event.getFrom().getBlockX() * 8, event.getFrom().getBlockY(), event.getFrom().getBlockZ() * 8);
+//            }
+//            event.setTo(event.getPortalTravelAgent().findOrCreate(location));
+//        }
+//
+//        if (event.getCause() == PlayerTeleportEvent.TeleportCause.END_PORTAL) {
+//            if (player.getWorld() == getWorld()) {
+//                Location loc = new Location(getEnd(), 100, 50, 0); // This is the vanilla location for obsidian platform.
+//                event.setTo(loc);
+//                Block block = loc.getBlock();
+//                for (int x = block.getX() - 2; x <= block.getX() + 2; x++) {
+//                    for (int z = block.getZ() - 2; z <= block.getZ() + 2; z++) {
+//                        Block platformBlock = loc.getWorld().getBlockAt(x, block.getY() - 1, z);
+//                        if (platformBlock.getType() != Material.OBSIDIAN) {
+//                            platformBlock.setType(Material.OBSIDIAN);
+//                        }
+//                        for (int yMod = 1; yMod <= 3; yMod++) {
+//                            Block b = platformBlock.getRelative(BlockFace.UP, yMod);
+//                            if (b.getType() != Material.AIR) {
+//                                b.setType(Material.AIR);
+//                            }
+//                        }
+//                    }
+//                }
+//            } else if (player.getWorld() == getEnd()) {
+//                event.setTo(getWorld().getSpawnLocation());
+//            }
+//        }
+//    }
+
+    private World getWorld() {
+        World world;
+        try {
+            world = CustomWorldManager.overWorld;
+        } catch (NullPointerException e) {
+            System.out.println("Custom over world could not be found.");
+            world = server.getWorlds().get(0);
+        }
+        return world;
+    }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -68,4 +68,26 @@ public class CustomPortalListener implements Listener {
         }
         return world;
     }
+
+    private World getNether() {
+        World world;
+        try {
+            world = CustomWorldManager.nether;
+        } catch (NullPointerException e) {
+            System.out.println("Custom nether could not be found.");
+            world = server.getWorlds().get(1);
+        }
+        return world;
+    }
+
+    private World getEnd() {
+        World world;
+        try {
+            world = CustomWorldManager.end;
+        } catch (NullPointerException e) {
+            System.out.println("Custom end could not be found.");
+            world = server.getWorlds().get(2);
+        }
+        return world;
+    }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/CustomPortalListener.java
@@ -56,9 +56,19 @@ public class CustomPortalListener implements Listener {
         }
     }
 
+    /**
+     * makes sure that when the player leaves the end from a custom end they will return back to custom over world.
+     * this method is needed because onPortal doesn't get triggered when a player goes from the end to over world.
+     * @param e - the event of a player after changing worlds.
+     */
     @EventHandler
-    public void onEndLeave(PlayerChangedWorldEvent event) {
-        
+    public void onEndLeave(PlayerChangedWorldEvent e) {
+        if(e.getFrom() == getEnd()) {
+            if(e.getPlayer().getBedSpawnLocation().getWorld() == getWorld()) {
+                return;
+            }
+            e.getPlayer().teleport(getWorld().getSpawnLocation());
+        }
     }
 
     /**

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/ProjectileBuff.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/ProjectileBuff.java
@@ -1,5 +1,6 @@
 package nl.pjiwm.kaizominecraft.listeners;
 
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
 import org.bukkit.entity.Blaze;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
@@ -12,9 +13,14 @@ public class ProjectileBuff implements Listener {
      * If the shooter of the projectile is a ghast the explosion of the fireball it shoots will be increased.
      * If the shooter of the projectile is a blaze the time a player is set on fire from the fireball is
      * extended to 400 ticks.
+     * If the projectile however is not from a custom world it will not be buffed.
      */
     @EventHandler
     public void shootProjectile(ProjectileLaunchEvent e) {
+        if(!CustomWorldManager.isCustomWorld(e.getLocation().getWorld().getName())) {
+            return;
+        }
+
         if (e.getEntity().getShooter() instanceof Ghast) {
             Fireball fireball = (Fireball) e.getEntity();
             fireball.setYield(15);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnBuffedMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnBuffedMob.java
@@ -1,5 +1,6 @@
 package nl.pjiwm.kaizominecraft.listeners;
 
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -20,6 +21,9 @@ public class SpawnBuffedMob implements Listener {
 
     @EventHandler
     public void spawnEntity(EntitySpawnEvent e) {
+        if(!CustomWorldManager.isCustomWorld(e.getLocation().getWorld().getName())) {
+            return;
+        }
         Entity entity = e.getEntity();
         if (entity instanceof Monster) {
             buffMonster(entity);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -12,7 +12,7 @@ public class SpawnCustomMob implements Listener {
      * Every entity that's being spawned gets passed down to the mob manager.
      * This way it can be checked if it can be replaced with a custom mob.
      * If the mob however is not from a custom world it will not be replaced.
-     * 
+     *
      * @param e - the event upon a new entity/mob spawns in the world.
      */
     @EventHandler

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SpawnCustomMob.java
@@ -1,6 +1,7 @@
 package nl.pjiwm.kaizominecraft.listeners;
 
 import nl.pjiwm.kaizominecraft.managers.CustomMobManager;
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntitySpawnEvent;
@@ -10,11 +11,15 @@ public class SpawnCustomMob implements Listener {
     /**
      * Every entity that's being spawned gets passed down to the mob manager.
      * This way it can be checked if it can be replaced with a custom mob.
+     * If the mob however is not from a custom world it will not be replaced.
+     * 
      * @param e - the event upon a new entity/mob spawns in the world.
      */
     @EventHandler
     public void spawnEntity(EntitySpawnEvent e) {
-        CustomMobManager.replaceMob(e.getEntity());
+        if(CustomWorldManager.isCustomWorld(e.getLocation().getWorld().getName())) {
+            CustomMobManager.replaceMob(e.getEntity());
+        }
     }
 
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SwapWorld.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SwapWorld.java
@@ -1,0 +1,2 @@
+package nl.pjiwm.kaizominecraft.listeners;public class SwapWorld {
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/SwapWorld.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/SwapWorld.java
@@ -1,2 +1,0 @@
-package nl.pjiwm.kaizominecraft.listeners;public class SwapWorld {
-}

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
@@ -26,6 +26,7 @@ public class TestWorldChangeListener implements Listener {
             e.getPlayer().sendMessage("swapped to world" + CustomWorldManager.OVERWORLD_NAME);
 //            this should be implemented in some way as a command later on.
             e.getPlayer().setBedSpawnLocation(e.getPlayer().getLocation());
+
         }
         if(e.getNewGameMode().equals(GameMode.SURVIVAL)) {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.CUSTOM);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
@@ -23,13 +23,11 @@ public class TestWorldChangeListener implements Listener {
         if(e.getNewGameMode().equals(GameMode.ADVENTURE)) {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.NORMAL);
             playerManager.restorePlayer(e.getPlayer(), WorldTypes.CUSTOM);
-//            e.getPlayer().teleport(server.getWorld(CustomWorldManager.OVERWORLD_NAME).getSpawnLocation());
             e.getPlayer().sendMessage("swapped to world" + CustomWorldManager.OVERWORLD_NAME);
         }
         if(e.getNewGameMode().equals(GameMode.SURVIVAL)) {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.CUSTOM);
             playerManager.restorePlayer(e.getPlayer(), WorldTypes.NORMAL);
-//            e.getPlayer().teleport(server.getWorlds().get(0).getSpawnLocation());
             e.getPlayer().sendMessage("swapped to world" + server.getWorlds().get(0).getName());
         }
     }

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
@@ -24,6 +24,8 @@ public class TestWorldChangeListener implements Listener {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.NORMAL);
             playerManager.restorePlayer(e.getPlayer(), WorldTypes.CUSTOM);
             e.getPlayer().sendMessage("swapped to world" + CustomWorldManager.OVERWORLD_NAME);
+//            this should be implemented in some way as a command later on.
+            e.getPlayer().setBedSpawnLocation(e.getPlayer().getLocation());
         }
         if(e.getNewGameMode().equals(GameMode.SURVIVAL)) {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.CUSTOM);

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
@@ -1,0 +1,36 @@
+package nl.pjiwm.kaizominecraft.listeners;
+
+import nl.pjiwm.kaizominecraft.managers.CustomWorldManager;
+import nl.pjiwm.kaizominecraft.managers.PlayerManager;
+import nl.pjiwm.kaizominecraft.managers.WorldTypes;
+import org.bukkit.GameMode;
+import org.bukkit.Server;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerGameModeChangeEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class TestWorldChangeListener implements Listener {
+    private Server server;
+    private PlayerManager playerManager;
+    public TestWorldChangeListener(JavaPlugin plugin) {
+        this.server = plugin.getServer();
+        this.playerManager = new PlayerManager(plugin);
+    }
+
+    @EventHandler
+    public void toCustomWorld(PlayerGameModeChangeEvent e) {
+        if(e.getNewGameMode().equals(GameMode.ADVENTURE)) {
+            playerManager.savePlayer(e.getPlayer(), WorldTypes.NORMAL);
+            playerManager.restorePlayer(e.getPlayer(), WorldTypes.NORMAL);
+            e.getPlayer().teleport(server.getWorld(CustomWorldManager.OVERWORLD_NAME).getSpawnLocation());
+            e.getPlayer().sendMessage("swapped to world" + CustomWorldManager.OVERWORLD_NAME);
+        }
+        if(e.getNewGameMode().equals(GameMode.SURVIVAL)) {
+            playerManager.savePlayer(e.getPlayer(), WorldTypes.CUSTOM);
+            playerManager.restorePlayer(e.getPlayer(), WorldTypes.CUSTOM);
+            e.getPlayer().teleport(server.getWorlds().get(0).getSpawnLocation());
+            e.getPlayer().sendMessage("swapped to world" + server.getWorlds().get(0).getName());
+        }
+    }
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/listeners/TestWorldChangeListener.java
@@ -22,14 +22,14 @@ public class TestWorldChangeListener implements Listener {
     public void toCustomWorld(PlayerGameModeChangeEvent e) {
         if(e.getNewGameMode().equals(GameMode.ADVENTURE)) {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.NORMAL);
-            playerManager.restorePlayer(e.getPlayer(), WorldTypes.NORMAL);
-            e.getPlayer().teleport(server.getWorld(CustomWorldManager.OVERWORLD_NAME).getSpawnLocation());
+            playerManager.restorePlayer(e.getPlayer(), WorldTypes.CUSTOM);
+//            e.getPlayer().teleport(server.getWorld(CustomWorldManager.OVERWORLD_NAME).getSpawnLocation());
             e.getPlayer().sendMessage("swapped to world" + CustomWorldManager.OVERWORLD_NAME);
         }
         if(e.getNewGameMode().equals(GameMode.SURVIVAL)) {
             playerManager.savePlayer(e.getPlayer(), WorldTypes.CUSTOM);
-            playerManager.restorePlayer(e.getPlayer(), WorldTypes.CUSTOM);
-            e.getPlayer().teleport(server.getWorlds().get(0).getSpawnLocation());
+            playerManager.restorePlayer(e.getPlayer(), WorldTypes.NORMAL);
+//            e.getPlayer().teleport(server.getWorlds().get(0).getSpawnLocation());
             e.getPlayer().sendMessage("swapped to world" + server.getWorlds().get(0).getName());
         }
     }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
@@ -21,7 +21,6 @@ public class CustomMobWorldSpawner {
             if (!entity.getPersistentDataContainer().has(CustomMobManager.entityKey, PersistentDataType.STRING)) {
                 CustomMobManager.replaceMob(entity);
             }
-
         }
     }
     /**

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomMobWorldSpawner.java
@@ -1,7 +1,6 @@
 package nl.pjiwm.kaizominecraft.managers;
 
 import org.bukkit.World;
-import org.bukkit.WorldType;
 import org.bukkit.entity.Entity;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,27 +12,16 @@ public class CustomMobWorldSpawner {
      * Goes through all existing entities in a world and replaces them.
      * If the mob does not have the namedSpaceKey "custom" of the type String
      * and has a custom mob variant it will be removed and a new custom mob will be spawned instead.
+     *
      * @param world - the world in which all mobs will be scanned.
      */
     public static void replaceMobs(World world) {
         List<Entity> allEntities = world.getEntities();
-        for(Entity entity : allEntities) {
-            if(!entity.getPersistentDataContainer().has(CustomMobManager.entityKey, PersistentDataType.STRING)) {
+        for (Entity entity : allEntities) {
+            if (!entity.getPersistentDataContainer().has(CustomMobManager.entityKey, PersistentDataType.STRING)) {
                 CustomMobManager.replaceMob(entity);
             }
 
-        }
-    }
-    /**
-     * gets all worlds from a server and does a scan on all entities on all worlds.
-     * On every world the replaceMobs method will be executed which replaces the mob with
-     * a custom mob if necessary.
-     * @param plugin - the main class/server plugin required to get all the servers worlds.
-     */
-    public static void replaceAllWorlds(JavaPlugin plugin) {
-        List<World> allWorlds = plugin.getServer().getWorlds();
-        for(World world : allWorlds) {
-            replaceMobs(world);
         }
     }
     /**
@@ -41,15 +29,16 @@ public class CustomMobWorldSpawner {
      * it does a scan on all entities on all worlds.
      * On every world the replaceMobs method will be executed which replaces the mob with
      * a custom mob if necessary.
+     *
      * @param plugin - the main class/server plugin required to get all the servers worlds.
-     * @param environment - the type of world it should perform actions on.
-     * options: NORMAL/NETHER/THE_END/CUSTOM
+     * @param worldNames - A list of world names where custom mobs should spawn.
      */
-    public static void replaceAllWorlds(JavaPlugin plugin, World.Environment environment) {
+    public static void replaceWorlds(JavaPlugin plugin, List<String> worldNames) {
         List<World> allWorlds = plugin.getServer().getWorlds();
-        for(World world : allWorlds) {
-            if(world.getEnvironment().equals(environment))
-            replaceMobs(world);
+        for (World world : allWorlds) {
+            if (worldNames.contains(world.getName())) {
+                replaceMobs(world);
+            }
         }
     }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -1,0 +1,109 @@
+package nl.pjiwm.kaizominecraft.managers;
+
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.WorldType;
+
+public class CustomWorldManager {
+    public final static String OVERWORLD_NAME = "kaizo";
+    public final static String NEHTER_NAME = "kaizo_nether";
+    public final static String END_NAME = "kaizo_end";
+    public static World overWorld;
+//    THIS IS TEMPORARY
+    public final static String JSON = "{\n" +
+            "\t\"useCaves\": true,\n" +
+            "\t\"useStrongholds\": true,\n" +
+            "\t\"useVillages\": true,\n" +
+            "\t\"useMineShafts\": true,\n" +
+            "\t\"useTemples\": true,\n" +
+            "\t\"useRavines\": true,\n" +
+            "\t\"useMonuments\": true,\n" +
+            "\t\"useMansions\": true,\n" +
+            "\t\"useLavaOceans\": false,\n" +
+            "\t\"useWaterLakes\": true,\n" +
+            "\t\"useLavaLakes\": true,\n" +
+            "\t\"useDungeons\": true,\n" +
+            "\t\"fixedBiome\": -3,\n" +
+            "\t\"biomeSize\": 6,\n" +
+            "\t\"seaLevel\": 40,\n" +
+            "\t\"riverSize\": 4,\n" +
+            "\t\"waterLakeChance\": 4,\n" +
+            "\t\"lavaLakeChance\": 100,\n" +
+            "\t\"dungeonChance\": 12,\n" +
+            "\t\"dirtSize\": 33,\n" +
+            "\t\"dirtCount\": 10,\n" +
+            "\t\"dirtMinHeight\": 0,\n" +
+            "\t\"dirtMaxHeight\": 255,\n" +
+            "\t\"gravelSize\": 33,\n" +
+            "\t\"gravelCount\": 8,\n" +
+            "\t\"gravelMinHeight\": 0,\n" +
+            "\t\"gravelMaxHeight\": 255,\n" +
+            "\t\"graniteSize\": 33,\n" +
+            "\t\"graniteCount\": 10,\n" +
+            "\t\"graniteMinHeight\": 0,\n" +
+            "\t\"graniteMaxHeight\": 80,\n" +
+            "\t\"dioriteSize\": 33,\n" +
+            "\t\"dioriteCount\": 10,\n" +
+            "\t\"dioriteMinHeight\": 0,\n" +
+            "\t\"dioriteMaxHeight\": 80,\n" +
+            "\t\"andesiteSize\": 33,\n" +
+            "\t\"andesiteCount\": 10,\n" +
+            "\t\"andesiteMinHeight\": 0,\n" +
+            "\t\"andesiteMaxHeight\": 80,\n" +
+            "\t\"coalSize\": 8,\n" +
+            "\t\"coalCount\": 18,\n" +
+            "\t\"coalMinHeight\": 0,\n" +
+            "\t\"coalMaxHeight\": 128,\n" +
+            "\t\"ironSize\": 5,\n" +
+            "\t\"ironCount\": 15,\n" +
+            "\t\"ironMinHeight\": 0,\n" +
+            "\t\"ironMaxHeight\": 50,\n" +
+            "\t\"goldSize\": 8,\n" +
+            "\t\"goldCount\": 2,\n" +
+            "\t\"goldMinHeight\": 0,\n" +
+            "\t\"goldMaxHeight\": 32,\n" +
+            "\t\"redstoneSize\": 8,\n" +
+            "\t\"redstoneCount\": 8,\n" +
+            "\t\"redstoneMinHeight\": 0,\n" +
+            "\t\"redstoneMaxHeight\": 16,\n" +
+            "\t\"diamondSize\": 6,\n" +
+            "\t\"diamondCount\": 1,\n" +
+            "\t\"diamondMinHeight\": 0,\n" +
+            "\t\"diamondMaxHeight\": 15,\n" +
+            "\t\"lapisSize\": 7,\n" +
+            "\t\"lapisCount\": 1,\n" +
+            "\t\"lapisMinHeight\": 0,\n" +
+            "\t\"lapisMaxHeight\": 32,\n" +
+            "\t\"coordinateScale\": 684,\n" +
+            "\t\"heightScale\": 736,\n" +
+            "\t\"mainNoiseScaleX\": 1000,\n" +
+            "\t\"mainNoiseScaleY\": 3000,\n" +
+            "\t\"mainNoiseScaleZ\": 1000,\n" +
+            "\t\"depthNoiseScaleX\": 200,\n" +
+            "\t\"depthNoiseScaleZ\": 200,\n" +
+            "\t\"depthNoiseScaleExponent\": 0.5,\n" +
+            "\t\"biomeDepthWeight\": 1,\n" +
+            "\t\"biomeDepthOffset\": 0,\n" +
+            "\t\"biomeScaleWeight\": 1,\n" +
+            "\t\"biomeScaleOffset\": 1,\n" +
+            "\t\"lowerLimitScale\": 512,\n" +
+            "\t\"upperLimitScale\": 512,\n" +
+            "\t\"baseSize\": 8.5,\n" +
+            "\t\"stretchY\": 10,\n" +
+            "\t\"lapisCenterHeight\": 16,\n" +
+            "\t\"lapisSpread\": 16\n" +
+            "}";
+
+    /**
+     * generates all custom worlds that are required.
+     */
+    public void geneRateWorlds() {
+//        overworld
+        WorldCreator worldCreator = new WorldCreator(OVERWORLD_NAME);
+        worldCreator.type(WorldType.NORMAL);
+        worldCreator.generateStructures(true);
+        worldCreator.generatorSettings(JSON);
+        overWorld = worldCreator.createWorld();
+
+    }
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -98,12 +98,17 @@ public class CustomWorldManager {
      */
     public static void geneRateWorlds() {
         World world;
+        WorldCreator worldCreator;
 //        overworld
-
-        WorldCreator worldCreator = new WorldCreator(OVERWORLD_NAME);
+        worldCreator = new WorldCreator(OVERWORLD_NAME);
         worldCreator.type(WorldType.NORMAL);
         worldCreator.generateStructures(true);
         worldCreator.generatorSettings(JSON);
+        world = worldCreator.createWorld();
+//         nether
+        worldCreator = new WorldCreator(NETHER_NAME);
+        worldCreator.environment(World.Environment.NETHER);
+        worldCreator.generateStructures(true);
         world = worldCreator.createWorld();
     }
     /**

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -97,7 +97,7 @@ public class CustomWorldManager {
     /**
      * generates all custom worlds that are required.
      */
-    public void geneRateWorlds() {
+    public static void geneRateWorlds() {
 //        overworld
         WorldCreator worldCreator = new WorldCreator(OVERWORLD_NAME);
         worldCreator.type(WorldType.NORMAL);

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -8,7 +8,40 @@ public class CustomWorldManager {
     public final static String OVERWORLD_NAME = "kaizo";
     public final static String NETHER_NAME = "kaizo_nether";
     public final static String END_NAME = "kaizo_end";
-//    THIS IS TEMPORARY
+
+    /**
+     * generates all custom worlds that are required.
+     */
+    public static void geneRateWorlds() {
+        World world;
+        WorldCreator worldCreator;
+//        overworld
+        worldCreator = new WorldCreator(OVERWORLD_NAME);
+        worldCreator.type(WorldType.NORMAL);
+        worldCreator.generateStructures(true);
+        worldCreator.generatorSettings(JSON);
+        world = worldCreator.createWorld();
+//         nether
+        worldCreator = new WorldCreator(NETHER_NAME);
+        worldCreator.environment(World.Environment.NETHER);
+        worldCreator.generateStructures(true);
+        world = worldCreator.createWorld();
+//        end
+        worldCreator = new WorldCreator(END_NAME);
+        worldCreator.environment(World.Environment.THE_END);
+        worldCreator.generateStructures(true);
+        world = worldCreator.createWorld();
+    }
+    /**
+     *
+     * @param worldName - the name of the world
+     * @return returns a boolean value if the world is custom or not.
+     */
+    public static boolean isCustomWorld(String worldName) {
+        return worldName.equals(OVERWORLD_NAME) || worldName.equals(NETHER_NAME) || worldName.equals(END_NAME);
+    }
+
+    //    THIS IS TEMPORARY
     public final static String JSON = "{\n" +
             "\t\"useCaves\": true,\n" +
             "\t\"useStrongholds\": true,\n" +
@@ -93,35 +126,4 @@ public class CustomWorldManager {
             "\t\"lapisSpread\": 16\n" +
             "}";
 
-    /**
-     * generates all custom worlds that are required.
-     */
-    public static void geneRateWorlds() {
-        World world;
-        WorldCreator worldCreator;
-//        overworld
-        worldCreator = new WorldCreator(OVERWORLD_NAME);
-        worldCreator.type(WorldType.NORMAL);
-        worldCreator.generateStructures(true);
-        worldCreator.generatorSettings(JSON);
-        world = worldCreator.createWorld();
-//         nether
-        worldCreator = new WorldCreator(NETHER_NAME);
-        worldCreator.environment(World.Environment.NETHER);
-        worldCreator.generateStructures(true);
-        world = worldCreator.createWorld();
-//        end
-        worldCreator = new WorldCreator(END_NAME);
-        worldCreator.environment(World.Environment.THE_END);
-        worldCreator.generateStructures(true);
-        world = worldCreator.createWorld();
-    }
-    /**
-     *
-     * @param worldName - the name of the world
-     * @return returns a boolean value if the world is custom or not.
-     */
-    public static boolean isCustomWorld(String worldName) {
-        return worldName.equals(OVERWORLD_NAME) || worldName.equals(NETHER_NAME) || worldName.equals(END_NAME);
-    }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -8,7 +8,6 @@ public class CustomWorldManager {
     public final static String OVERWORLD_NAME = "kaizo";
     public final static String NETHER_NAME = "kaizo_nether";
     public final static String END_NAME = "kaizo_end";
-    public static World overWorld;
 //    THIS IS TEMPORARY
     public final static String JSON = "{\n" +
             "\t\"useCaves\": true,\n" +
@@ -98,12 +97,14 @@ public class CustomWorldManager {
      * generates all custom worlds that are required.
      */
     public static void geneRateWorlds() {
+        World world;
 //        overworld
+
         WorldCreator worldCreator = new WorldCreator(OVERWORLD_NAME);
         worldCreator.type(WorldType.NORMAL);
         worldCreator.generateStructures(true);
         worldCreator.generatorSettings(JSON);
-        overWorld = worldCreator.createWorld();
+        world = worldCreator.createWorld();
     }
     /**
      *

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -8,30 +8,32 @@ public class CustomWorldManager {
     public final static String OVERWORLD_NAME = "kaizo";
     public final static String NETHER_NAME = "kaizo_nether";
     public final static String END_NAME = "kaizo_end";
+    public static World overWorld;
+    public static World nether;
+    public static World end;
 
     /**
      * generates all custom worlds that are required.
      */
     public static void geneRateWorlds() {
-        World world;
         WorldCreator worldCreator;
 //        overworld
         worldCreator = new WorldCreator(OVERWORLD_NAME);
         worldCreator.type(WorldType.NORMAL);
         worldCreator.generateStructures(true);
         worldCreator.generatorSettings(JSON);
-        world = worldCreator.createWorld();
+        overWorld = worldCreator.createWorld();
 //         nether
         worldCreator = new WorldCreator(NETHER_NAME);
         worldCreator.environment(World.Environment.NETHER);
         worldCreator.generateStructures(true);
         worldCreator.generatorSettings(netherJSON);
-        world = worldCreator.createWorld();
+        nether = worldCreator.createWorld();
 //        end
         worldCreator = new WorldCreator(END_NAME);
         worldCreator.environment(World.Environment.THE_END);
         worldCreator.generateStructures(true);
-        world = worldCreator.createWorld();
+        end = worldCreator.createWorld();
     }
     /**
      *

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -106,4 +106,12 @@ public class CustomWorldManager {
         overWorld = worldCreator.createWorld();
 
     }
+    /**
+     *
+     * @param worldName - the name of the world
+     * @return returns a boolean value if the world is custom or not.
+     */
+    public static boolean isCustomWorld(String worldName) {
+        return worldName.equals(OVERWORLD_NAME) || worldName.equals(NEHTER_NAME) || worldName.equals(END_NAME);
+    }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -104,7 +104,6 @@ public class CustomWorldManager {
         worldCreator.generateStructures(true);
         worldCreator.generatorSettings(JSON);
         overWorld = worldCreator.createWorld();
-
     }
     /**
      *

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -110,6 +110,11 @@ public class CustomWorldManager {
         worldCreator.environment(World.Environment.NETHER);
         worldCreator.generateStructures(true);
         world = worldCreator.createWorld();
+//        end
+        worldCreator = new WorldCreator(END_NAME);
+        worldCreator.environment(World.Environment.THE_END);
+        worldCreator.generateStructures(true);
+        world = worldCreator.createWorld();
     }
     /**
      *

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -25,12 +25,12 @@ public class CustomWorldManager {
         worldCreator = new WorldCreator(NETHER_NAME);
         worldCreator.environment(World.Environment.NETHER);
         worldCreator.generateStructures(true);
+        worldCreator.generatorSettings(netherJSON);
         world = worldCreator.createWorld();
 //        end
         worldCreator = new WorldCreator(END_NAME);
         worldCreator.environment(World.Environment.THE_END);
         worldCreator.generateStructures(true);
-        worldCreator.generatorSettings(netherJSON);
         world = worldCreator.createWorld();
     }
     /**

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -6,7 +6,7 @@ import org.bukkit.WorldType;
 
 public class CustomWorldManager {
     public final static String OVERWORLD_NAME = "kaizo";
-    public final static String NEHTER_NAME = "kaizo_nether";
+    public final static String NETHER_NAME = "kaizo_nether";
     public final static String END_NAME = "kaizo_end";
     public static World overWorld;
 //    THIS IS TEMPORARY
@@ -111,6 +111,6 @@ public class CustomWorldManager {
      * @return returns a boolean value if the world is custom or not.
      */
     public static boolean isCustomWorld(String worldName) {
-        return worldName.equals(OVERWORLD_NAME) || worldName.equals(NEHTER_NAME) || worldName.equals(END_NAME);
+        return worldName.equals(OVERWORLD_NAME) || worldName.equals(NETHER_NAME) || worldName.equals(END_NAME);
     }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -21,18 +21,16 @@ public class CustomWorldManager {
         worldCreator = new WorldCreator(OVERWORLD_NAME);
         worldCreator.type(WorldType.NORMAL);
         worldCreator.generateStructures(true);
-        worldCreator.generatorSettings(JSON);
+        worldCreator.type(WorldType.AMPLIFIED);
         overWorld = worldCreator.createWorld();
 //         nether
         worldCreator = new WorldCreator(NETHER_NAME);
         worldCreator.environment(World.Environment.NETHER);
         worldCreator.generateStructures(true);
-        worldCreator.generatorSettings(netherJSON);
         nether = worldCreator.createWorld();
 //        end
         worldCreator = new WorldCreator(END_NAME);
         worldCreator.environment(World.Environment.THE_END);
-        worldCreator.generateStructures(true);
         end = worldCreator.createWorld();
     }
     /**
@@ -43,91 +41,4 @@ public class CustomWorldManager {
     public static boolean isCustomWorld(String worldName) {
         return worldName.equals(OVERWORLD_NAME) || worldName.equals(NETHER_NAME) || worldName.equals(END_NAME);
     }
-
-    //    THIS IS TEMPORARY
-    public final static String JSON = "{\n" +
-            "\t\"useCaves\": true,\n" +
-            "\t\"useStrongholds\": true,\n" +
-            "\t\"useVillages\": true,\n" +
-            "\t\"useMineShafts\": true,\n" +
-            "\t\"useTemples\": true,\n" +
-            "\t\"useRavines\": true,\n" +
-            "\t\"useMonuments\": true,\n" +
-            "\t\"useMansions\": true,\n" +
-            "\t\"useLavaOceans\": false,\n" +
-            "\t\"useWaterLakes\": true,\n" +
-            "\t\"useLavaLakes\": true,\n" +
-            "\t\"useDungeons\": true,\n" +
-            "\t\"fixedBiome\": -3,\n" +
-            "\t\"biomeSize\": 6,\n" +
-            "\t\"seaLevel\": 40,\n" +
-            "\t\"riverSize\": 4,\n" +
-            "\t\"waterLakeChance\": 4,\n" +
-            "\t\"lavaLakeChance\": 100,\n" +
-            "\t\"dungeonChance\": 12,\n" +
-            "\t\"dirtSize\": 33,\n" +
-            "\t\"dirtCount\": 10,\n" +
-            "\t\"dirtMinHeight\": 0,\n" +
-            "\t\"dirtMaxHeight\": 255,\n" +
-            "\t\"gravelSize\": 33,\n" +
-            "\t\"gravelCount\": 8,\n" +
-            "\t\"gravelMinHeight\": 0,\n" +
-            "\t\"gravelMaxHeight\": 255,\n" +
-            "\t\"graniteSize\": 33,\n" +
-            "\t\"graniteCount\": 10,\n" +
-            "\t\"graniteMinHeight\": 0,\n" +
-            "\t\"graniteMaxHeight\": 80,\n" +
-            "\t\"dioriteSize\": 33,\n" +
-            "\t\"dioriteCount\": 10,\n" +
-            "\t\"dioriteMinHeight\": 0,\n" +
-            "\t\"dioriteMaxHeight\": 80,\n" +
-            "\t\"andesiteSize\": 33,\n" +
-            "\t\"andesiteCount\": 10,\n" +
-            "\t\"andesiteMinHeight\": 0,\n" +
-            "\t\"andesiteMaxHeight\": 80,\n" +
-            "\t\"coalSize\": 8,\n" +
-            "\t\"coalCount\": 18,\n" +
-            "\t\"coalMinHeight\": 0,\n" +
-            "\t\"coalMaxHeight\": 128,\n" +
-            "\t\"ironSize\": 5,\n" +
-            "\t\"ironCount\": 15,\n" +
-            "\t\"ironMinHeight\": 0,\n" +
-            "\t\"ironMaxHeight\": 50,\n" +
-            "\t\"goldSize\": 8,\n" +
-            "\t\"goldCount\": 2,\n" +
-            "\t\"goldMinHeight\": 0,\n" +
-            "\t\"goldMaxHeight\": 32,\n" +
-            "\t\"redstoneSize\": 8,\n" +
-            "\t\"redstoneCount\": 8,\n" +
-            "\t\"redstoneMinHeight\": 0,\n" +
-            "\t\"redstoneMaxHeight\": 16,\n" +
-            "\t\"diamondSize\": 6,\n" +
-            "\t\"diamondCount\": 1,\n" +
-            "\t\"diamondMinHeight\": 0,\n" +
-            "\t\"diamondMaxHeight\": 15,\n" +
-            "\t\"lapisSize\": 7,\n" +
-            "\t\"lapisCount\": 1,\n" +
-            "\t\"lapisMinHeight\": 0,\n" +
-            "\t\"lapisMaxHeight\": 32,\n" +
-            "\t\"coordinateScale\": 684,\n" +
-            "\t\"heightScale\": 736,\n" +
-            "\t\"mainNoiseScaleX\": 1000,\n" +
-            "\t\"mainNoiseScaleY\": 3000,\n" +
-            "\t\"mainNoiseScaleZ\": 1000,\n" +
-            "\t\"depthNoiseScaleX\": 200,\n" +
-            "\t\"depthNoiseScaleZ\": 200,\n" +
-            "\t\"depthNoiseScaleExponent\": 0.5,\n" +
-            "\t\"biomeDepthWeight\": 1,\n" +
-            "\t\"biomeDepthOffset\": 0,\n" +
-            "\t\"biomeScaleWeight\": 1,\n" +
-            "\t\"biomeScaleOffset\": 1,\n" +
-            "\t\"lowerLimitScale\": 512,\n" +
-            "\t\"upperLimitScale\": 512,\n" +
-            "\t\"baseSize\": 8.5,\n" +
-            "\t\"stretchY\": 10,\n" +
-            "\t\"lapisCenterHeight\": 16,\n" +
-            "\t\"lapisSpread\": 16\n" +
-            "}";
-    private final static String netherJSON = "\"settings\": \"minecraft:floating_islands\"";
-
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/CustomWorldManager.java
@@ -30,6 +30,7 @@ public class CustomWorldManager {
         worldCreator = new WorldCreator(END_NAME);
         worldCreator.environment(World.Environment.THE_END);
         worldCreator.generateStructures(true);
+        worldCreator.generatorSettings(netherJSON);
         world = worldCreator.createWorld();
     }
     /**
@@ -125,5 +126,6 @@ public class CustomWorldManager {
             "\t\"lapisCenterHeight\": 16,\n" +
             "\t\"lapisSpread\": 16\n" +
             "}";
+    private final static String netherJSON = "\"settings\": \"minecraft:floating_islands\"";
 
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
@@ -2,10 +2,7 @@ package nl.pjiwm.kaizominecraft.managers;
 
 
 
-import nl.pjiwm.kaizominecraft.listeners.ArrowBuff;
-import nl.pjiwm.kaizominecraft.listeners.ProjectileBuff;
-import nl.pjiwm.kaizominecraft.listeners.SpawnBuffedMob;
-import nl.pjiwm.kaizominecraft.listeners.SpawnCustomMob;
+import nl.pjiwm.kaizominecraft.listeners.*;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -16,5 +13,6 @@ public class EventRegisterer {
         pm.registerEvents(new SpawnBuffedMob(), plugin);
         pm.registerEvents(new ProjectileBuff(), plugin);
         pm.registerEvents(new ArrowBuff(), plugin);
+        pm.registerEvents(new TestWorldChangeListener(plugin), plugin);
     }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
@@ -11,7 +11,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class EventRegisterer {
 
-
     public static void registerEvents(PluginManager pm, JavaPlugin plugin) {
         pm.registerEvents(new SpawnCustomMob(), plugin);
         pm.registerEvents(new SpawnBuffedMob(), plugin);

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/EventRegisterer.java
@@ -14,5 +14,6 @@ public class EventRegisterer {
         pm.registerEvents(new ProjectileBuff(), plugin);
         pm.registerEvents(new ArrowBuff(), plugin);
         pm.registerEvents(new TestWorldChangeListener(plugin), plugin);
+        pm.registerEvents(new CustomPortalListener(plugin), plugin);
     }
 }

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
@@ -106,8 +106,14 @@ public class PlayerManager {
      * @param worldType the type of world the player is in, whether it's custom or not.
      */
     public void savePlayer(Player p, WorldTypes worldType) {
+        Location location;
+        if(worldType.equals(WorldTypes.NORMAL)) {
+            location = p.getLocation();
+        } else {
+            location = plugin.getServer().getWorld(CustomWorldManager.OVERWORLD_NAME).getSpawnLocation();
+        }
         YamlConfiguration playerConfig = new YamlConfiguration();
-        playerConfig.set("location", LocationUtils.locToConfigSection(p.getLocation()));
+        playerConfig.set("location", LocationUtils.locToConfigSection(location));
         playerConfig.set("inventory", p.getInventory().getContents());
         playerConfig.set("health", p.getHealth());
         playerConfig.set("hunger", p.getFoodLevel());

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
@@ -110,6 +110,7 @@ public class PlayerManager {
         playerConfig.set("health", p.getHealth());
         playerConfig.set("hunger", p.getFoodLevel());
         playerConfig.set("xp", p.getTotalExperience());
+        save(p, playerConfig, worldType);
     }
 
     /**
@@ -131,7 +132,6 @@ public class PlayerManager {
         } else {
             playerConfig = getPlayerConfig(p, WorldTypes.NORMAL);
         }
-        savePlayer(p, worldType);
 
         if (playerConfig == null)
             return;

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
@@ -14,7 +14,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-
+//TODO - fix bug player not teleporting
 public class PlayerManager {
     private JavaPlugin plugin;
     private File folder;
@@ -51,8 +51,10 @@ public class PlayerManager {
      */
     private FileConfiguration getPlayerConfig(Player p, WorldTypes worldType) {
         File playerFile = getPlayerFile(p, worldType);
-        if (!playerFile.exists())
+        if (!playerFile.exists()) {
+            System.out.println("Playerconfig for" + worldType + " no exisot");
             return null;
+        }
 
         YamlConfiguration playerConfig = new YamlConfiguration();
         try {
@@ -120,21 +122,18 @@ public class PlayerManager {
      * And it check if the player has something saved otherwise it does nothing
      *
      * @param p The player to restore the location, inventory and armor from
-     * @param p the world type the player is in so we can store a new variant of the other world type and remove current one.
+     * @param worldType the type of world you want to restore the players data.
      */
     public void restorePlayer(Player p, WorldTypes worldType ) {
         if (Bukkit.getPlayerExact(p.getName()) == null)
             return;
         FileConfiguration playerConfig;
 
-        if(worldType.equals(WorldTypes.NORMAL)) {
-            playerConfig = getPlayerConfig(p, WorldTypes.CUSTOM);
-        } else {
-            playerConfig = getPlayerConfig(p, WorldTypes.NORMAL);
-        }
+        playerConfig = getPlayerConfig(p, worldType);
 
-        if (playerConfig == null)
+        if (playerConfig == null) {
             return;
+        }
 
         Location location = LocationUtils.configSectionToLocation(playerConfig.getConfigurationSection("location"));
         List<ItemStack> contentList = (List<ItemStack>) playerConfig.get("inventory");

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
@@ -1,0 +1,154 @@
+package nl.pjiwm.kaizominecraft.managers;
+
+import nl.pjiwm.kaizominecraft.utils.LocationUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+public class PlayerManager {
+    private JavaPlugin plugin;
+    private File folder;
+    public PlayerManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        initFolder();
+    }
+
+    /**
+     * This method allow us to init the folder containing the player-data, it also create it if it does not exists.
+     */
+    public void initFolder() {
+        folder = new File(plugin.getDataFolder(), "player-data");
+        if (!folder.exists())
+            folder.mkdirs();
+    }
+
+    /**
+     * This function allow us to get the File object pointing the the configs of the player
+     *
+     * @param player The player to get the file from
+     * @param worldType the world type the player is in, so each player can have stored data of custom and normal world.
+     * @return The File object associated to the configs of the player (does not check anything).
+     */
+    private File getPlayerFile(Player player, WorldTypes worldType) {
+        return new File(folder, player.getUniqueId().toString() + "-" + worldType);
+    }
+
+    /**
+     * This method allow us to get the YamlConfiguration of a player or null if no config is found
+     *
+     * @param p The player to get the configuration from
+     * @return The config of the player or null if no config is found or there is an error
+     */
+    private FileConfiguration getPlayerConfig(Player p, WorldTypes worldType) {
+        File playerFile = getPlayerFile(p, worldType);
+        if (!playerFile.exists())
+            return null;
+
+        YamlConfiguration playerConfig = new YamlConfiguration();
+        try {
+            playerConfig.load(playerFile);
+            return playerConfig;
+        } catch (InvalidConfigurationException e) {
+            e.printStackTrace();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * This method allow us to save the configs of a player
+     *
+     * @param p  The player to save the config from
+     * @param config The config that has to be saved
+     * @param worldType the world type the player is in.
+     */
+    private void save(Player p, FileConfiguration config, WorldTypes worldType) {
+        File playerFile = getPlayerFile(p, worldType);
+        try {
+            config.save(playerFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * This method allow us to delete the file of the player if it exists
+     *
+     * @param p The player to remove the file from
+     * @param worldType the type of world the player is in so we can remove the correct config variant.
+     */
+    private void removeConfigs(Player p, WorldTypes worldType) {
+        File playerFile = getPlayerFile(p, worldType);
+        if (playerFile.exists())
+            playerFile.delete();
+    }
+
+    /**
+     * This method allow us to save the location, inventory, armor, health, hunger and xp of a player.
+     * Call this method before teleporting the player inside of a new game
+     *
+     * @param p The player to save the stuff from.
+     * @param worldType the type of world the player is in, whether it's custom or not.
+     */
+    public void savePlayer(Player p, WorldTypes worldType) {
+        YamlConfiguration playerConfig = new YamlConfiguration();
+        playerConfig.set("location", LocationUtils.locToConfigSection(p.getLocation()));
+        playerConfig.set("inventory", p.getInventory().getContents());
+        playerConfig.set("health", p.getHealth());
+        playerConfig.set("hunger", p.getFoodLevel());
+        playerConfig.set("xp", p.getTotalExperience());
+    }
+
+    /**
+     * This function restore the location, inventory and armor of the player.
+     * It actually does more, it also checks if the player is connected if not it does nothing.
+     * It also remove the save of the player from configs
+     * And it check if the player has something saved otherwise it does nothing
+     *
+     * @param p The player to restore the location, inventory and armor from
+     * @param p the world type the player is in so we can store a new variant of the other world type and remove current one.
+     */
+    public void restorePlayer(Player p, WorldTypes worldType ) {
+        if (Bukkit.getPlayerExact(p.getName()) == null)
+            return;
+        FileConfiguration playerConfig;
+
+        if(worldType.equals(WorldTypes.NORMAL)) {
+            playerConfig = getPlayerConfig(p, WorldTypes.CUSTOM);
+        } else {
+            playerConfig = getPlayerConfig(p, WorldTypes.NORMAL);
+        }
+        savePlayer(p, worldType);
+
+        if (playerConfig == null)
+            return;
+
+        Location location = LocationUtils.configSectionToLocation(playerConfig.getConfigurationSection("location"));
+        List<ItemStack> contentList = (List<ItemStack>) playerConfig.get("inventory");
+        ItemStack[] inventoryContent = contentList.toArray(new ItemStack[contentList.size()]);
+        double health = playerConfig.getDouble("health");
+        int hunger = playerConfig.getInt("hunger");
+        int xp = playerConfig.getInt("xp");
+
+        p.teleport(location);
+        p.getInventory().setContents(inventoryContent);
+        p.setHealth(health);
+        p.setFoodLevel(hunger);
+        p.setTotalExperience(xp);
+
+        removeConfigs(p, worldType);
+    }
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/PlayerManager.java
@@ -14,7 +14,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-//TODO - fix bug player not teleporting
+
 public class PlayerManager {
     private JavaPlugin plugin;
     private File folder;

--- a/src/main/java/nl/pjiwm/kaizominecraft/managers/WorldTypes.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/managers/WorldTypes.java
@@ -1,0 +1,16 @@
+package nl.pjiwm.kaizominecraft.managers;
+
+public enum WorldTypes {
+    CUSTOM("custom"), NORMAL("normal");
+
+    private final String worldType;
+
+    WorldTypes(String worldType) {
+        this.worldType = worldType;
+    }
+
+    @Override
+    public String toString() {
+        return worldType;
+    }
+}

--- a/src/main/java/nl/pjiwm/kaizominecraft/utils/LocationUtils.java
+++ b/src/main/java/nl/pjiwm/kaizominecraft/utils/LocationUtils.java
@@ -1,0 +1,32 @@
+package nl.pjiwm.kaizominecraft.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+public class LocationUtils {
+    public static FileConfiguration locToConfigSection(Location location) {
+        FileConfiguration ret = new YamlConfiguration();
+        ret.set("world", location.getWorld().getName());
+        ret.set("x", location.getX());
+        ret.set("y", location.getY());
+        ret.set("z", location.getZ());
+        ret.set("pitch", "" + location.getPitch());
+        ret.set("yaw", "" + location.getYaw());
+        return ret;
+    }
+
+    public static Location configSectionToLocation(ConfigurationSection section) {
+        World world = Bukkit.getWorld(section.getString("world"));
+        double x = section.getDouble("x");
+        double y = section.getDouble("y");
+        double z = section.getDouble("z");
+        float pitch = Float.parseFloat(section.getString("pitch"));
+        float yaw = Float.parseFloat(section.getString("yaw"));
+
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

**Please provide enough information so that others can review your pull request:**
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
Apart from the normal Minecraft dimensions there should be a Kaizo variant of them.
The worlds should be linked together so when a player goes in a portal they still stay in the Kaizo variant.
All kaizo worlds need custom terrain which is created with minecraft own json system for creating custom worlds.

**Explain the **details** for making this change. What existing problem does the pull request solve?**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Upon starting up the server there should be a check if the worlds kaizo, kaizo_nether and kaizo_end exist.
If not these world should be created with custom generation parameters. 
These custom generation parameters need to be made with json that tells the plugin what to edit about the world.
The terrains should be made more difficult to traverse and give an over all more difficult feeling to them.
The following list of components should be added to implement this feature:

- [x] A world creation class that generates new custom worlds.
- [x] ~~3 json files/json strings that describe the custom terrain of each Minecraft dimension.~~
- [x] a way for a player to enter the world. This can be done via events or commands.
- [x] a way for the player to return back to the normal worlds. (might scrap or make admin only)
- [x] a listener that checks portal events in kaizo worlds so that the player stays in the kaizo worlds.
- [x] spawnpoint of the player should be changed upon entering kaizo dimension.
- [x] store seperate inventory and player data in kaizo world
- [x] change custom mob events that now only occur in the default minecraft world to kaizo variant.
- [x] prevent buffed mobs to spawn in normal world.

**Test plan (required):**
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request has visual changes.
1. remove kaizo world folders until the results are correct
2. join minecraft server and make sure player is in a kaizo world
3. check if features work within kaizo world

**Closing issues**

closes #11 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
